### PR TITLE
ログインしているユーザーのみ投稿した作品削除できるようにしました

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
+    if @item.user_id==current_user.id && @item.destroy
       redirect_to root_path, notice: '削除しました'
     else
       flash.now[:alert] = '削除できませんでした'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,9 +36,9 @@ class ItemsController < ApplicationController
     @category_child = Category.find(@category_id).parent
     @category_grandchild = Category.find(@category_id)
   end
+
   def destroy
-    @item= ItemImage.where(params[:id])
-    if @item.delete
+    if @item.destroy
       redirect_to root_path, notice: '削除しました'
     else
       flash.now[:alert] = '削除できませんでした'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @user = current_user
+    @items = current_user.items
     # @item_3 = @items.order('updated_at DESC').first(3)
     # @to_comments = Comment.where(user_id: current_user.id)
     # @be_commented = Comment.where.not(user_id: current_user.id).where(item_id: @items.ids)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -34,6 +34,18 @@
         .prof
           .prof__data
             登録日：#{current_user.created_at.strftime("%Y年%m月%d日")}
+      .user__body__subtitle
+        最近出品した商品
+      .user__body__lists
+        - @items.each do |item|
+          .user__body__lists__list
+            = link_to item_path(item.id), data: {"turbolinks" => false}  do
+              .main__pickup__product__list__img
+                -if item.buyer_id.present? 
+                  .items-box_photo__sold
+                    .items-box_photo__sold__inner SOLD
+                - else
+                  = image_tag(item.item_images.first.url.to_s,class: "main__photo")
           -# .prof__data
           -#   現在の出品数：
           -# .prof__data


### PR DESCRIPTION
#What
自分自身が投稿した商品のみ削除できるように機能を追加
#Why
ユーザーが間違えて投稿してしまったものを削除できるようにすることで誤った売買を未然に防ぐ